### PR TITLE
Ruby 1.9 compatibility

### DIFF
--- a/lib/paymium/api/client.rb
+++ b/lib/paymium/api/client.rb
@@ -23,7 +23,8 @@ module Paymium
       end
 
       def post path, params = {}, &block
-        req = Net::HTTP::Post.new(uri_from_path(path))
+        uri = uri_from_path(path)
+        req = Net::HTTP::Post.new(uri.request_uri)
         req.body = params.to_json
         request req, &block
       end
@@ -34,7 +35,9 @@ module Paymium
       def set_header_fields req
         key = @config[:key]
         nonce = (Time.now.to_f * 10**6).to_i
-        data = [nonce, req.uri.to_s, req.body].compact.join
+        uri = @host.dup
+        uri.path = req.path
+        data = [nonce, uri.to_s, req.body].compact.join
         sig = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), @config[:secret], data).strip
         req.add_field "Api-Key", key
         req.add_field "Api-Nonce", nonce

--- a/lib/paymium/api/client.rb
+++ b/lib/paymium/api/client.rb
@@ -19,7 +19,7 @@ module Paymium
       def get path, params = {}, &block
         uri       = uri_from_path(path)
         uri.query = URI.encode_www_form params unless params.empty?
-        request Net::HTTP::Get.new(uri), &block
+        request Net::HTTP::Get.new(uri.request_uri), &block
       end
 
       def post path, params = {}, &block
@@ -36,7 +36,7 @@ module Paymium
         key = @config[:key]
         nonce = (Time.now.to_f * 10**6).to_i
         uri = @host.dup
-        uri.path = req.path
+        uri.path, uri.query = req.path.split('?')
         data = [nonce, uri.to_s, req.body].compact.join
         sig = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), @config[:secret], data).strip
         req.add_field "Api-Key", key

--- a/lib/paymium/api/client.rb
+++ b/lib/paymium/api/client.rb
@@ -1,10 +1,10 @@
 require "active_support/hash_with_indifferent_access"
 require "active_support/core_ext/object/blank"
 require "net/http"
-require 'JSON'
+require 'json'
 
 require 'openssl'
-require 'Base64'
+require 'base64'
 
 
 module Paymium


### PR DESCRIPTION
The library doesn't work with Ruby 1.9 because Net::HTTP::Post cannot handle URI (it only handles paths). 

These changes makes the library compatible with Ruby 1.9.